### PR TITLE
feat/ssl: initial dev to create SSL tests

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// NodeCollector implements the prometheus.Collector interface.
+// MasterCollector implements the prometheus.Collector interface.
 type MasterCollector struct {
 	Collectors map[string]Collector
 	StkAPI     *stk.StkAPI
@@ -66,7 +66,7 @@ func registerCollector(collector string, isDefaultEnabled bool, factory func() (
 	factories[collector] = factory
 }
 
-// NewNodeCollector creates a new NodeCollector.
+// NewMasterCollector creates a new NodeCollector.
 func NewMasterCollector(stkAPI *stk.StkAPI, filters ...string) (*MasterCollector, error) {
 	f := make(map[string]bool)
 	for _, filter := range filters {
@@ -98,11 +98,9 @@ func NewMasterCollector(stkAPI *stk.StkAPI, filters ...string) (*MasterCollector
 	}, nil
 }
 
-//Each and every collector must implement the Describe function.
-//It essentially writes all descriptors to the prometheus desc channel.
+//Describe essentially writes all descriptors to the prometheus desc channel.
 func (mc *MasterCollector) Describe(ch chan<- *prometheus.Desc) {
 
-	//Update this section with the each metric you create for a given collector
 	ch <- scrapeDurationDesc
 	ch <- scrapeSuccessDesc
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -91,6 +91,7 @@ func NewMasterCollector(stkAPI *stk.StkAPI, filters ...string) (*MasterCollector
 			}
 		}
 	}
+	fmt.Println(collectors)
 	return &MasterCollector{
 		Collectors: collectors,
 		StkAPI:     stkAPI,

--- a/collector/ssl.go
+++ b/collector/ssl.go
@@ -1,0 +1,70 @@
+package collector
+
+import (
+	"fmt"
+
+	"github.com/mtulio/statuscake-exporter/stk"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type stkSSLCollector struct {
+	stkTestUp     *prometheus.Desc
+	stkTestUptime *prometheus.Desc
+	stkTestPerf   *prometheus.Desc
+	StkAPI        *stk.StkAPI
+}
+
+const (
+	stkSSLCollectorSubsystem = "ssl"
+)
+
+func init() {
+	registerCollector("ssl", defaultEnabled, NewStkSSLCollector)
+}
+
+//NewStkSSLCollector is a StatusCake SSL Collector
+func NewStkSSLCollector() (Collector, error) {
+	return &stkTestCollector{
+		stkTestUp: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "up"),
+			"StatusCake Test Status",
+			[]string{"name"}, nil,
+		),
+	}, nil
+}
+
+// Update implements Collector and exposes related metrics
+func (c *stkSSLCollector) Update(ch chan<- prometheus.Metric) error {
+	fmt.Println("ssl.Update()")
+	if err := c.updateStkSSL(ch); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *stkSSLCollector) UpdateConfig(stkAPI *stk.StkAPI) error {
+	c.StkAPI = stkAPI
+	return nil
+}
+
+func (c *stkSSLCollector) updateStkSSL(ch chan<- prometheus.Metric) error {
+	if c.StkAPI == nil {
+		return nil
+	}
+	tests := c.StkAPI.GetTestsSSL()
+	if len(tests) < 1 {
+		return nil
+	}
+	for t := range tests {
+		test := tests[t]
+		testStatus := 0
+		fmt.Println(test)
+		if test.Paused == false {
+			testStatus = 1
+		}
+		fmt.Println(testStatus)
+		fmt.Println(test)
+	}
+
+	return nil
+}

--- a/collector/ssl.go
+++ b/collector/ssl.go
@@ -1,17 +1,25 @@
 package collector
 
 import (
-	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/mtulio/statuscake-exporter/stk"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 type stkSSLCollector struct {
-	stkTestUp     *prometheus.Desc
-	stkTestUptime *prometheus.Desc
-	stkTestPerf   *prometheus.Desc
-	StkAPI        *stk.StkAPI
+	StkAPI              *stk.StkAPI
+	stkSslUp            *prometheus.Desc
+	stkSslCertScore     *prometheus.Desc
+	stkSslCipherScore   *prometheus.Desc
+	stkSslCertStatus    *prometheus.Desc
+	stkSslValidUntil    *prometheus.Desc
+	stkSslAlertReminder *prometheus.Desc
+	stkSslLastReminder  *prometheus.Desc
+	stkSslAlertExpiry   *prometheus.Desc
+	stkSslAlertBroken   *prometheus.Desc
+	stkSslAlertMixed    *prometheus.Desc
 }
 
 const (
@@ -24,18 +32,62 @@ func init() {
 
 //NewStkSSLCollector is a StatusCake SSL Collector
 func NewStkSSLCollector() (Collector, error) {
-	return &stkTestCollector{
-		stkTestUp: prometheus.NewDesc(
+	return &stkSSLCollector{
+		stkSslUp: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "up"),
-			"StatusCake Test Status",
-			[]string{"name"}, nil,
+			"StatusCake Test SSL Status",
+			[]string{"domain"}, nil,
+		),
+		stkSslCertScore: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "cert_score"),
+			"StatusCake SSL Certificate Score",
+			[]string{"domain"}, nil,
+		),
+		stkSslCipherScore: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "cipher_score"),
+			"StatusCake SSL Cipher Score",
+			[]string{"domain"}, nil,
+		),
+		stkSslCertStatus: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "cert_status"),
+			"StatusCake SSL Cert Status",
+			[]string{"domain"}, nil,
+		),
+		stkSslValidUntil: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "valid_util_sec"),
+			"StatusCake SSL Valid Until",
+			[]string{"domain"}, nil,
+		),
+		stkSslAlertReminder: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "alert_reminder"),
+			"StatusCake SSL Alert Reminder boolean",
+			[]string{"domain"}, nil,
+		),
+		stkSslLastReminder: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "last_reminder"),
+			"StatusCake SSL Last Reminder",
+			[]string{"domain"}, nil,
+		),
+		stkSslAlertExpiry: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "alert_expiry"),
+			"StatusCake SSL Alert Expiry boolean",
+			[]string{"domain"}, nil,
+		),
+		stkSslAlertBroken: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "alert_broken"),
+			"StatusCake SSL Alert Broken boolean",
+			[]string{"domain"}, nil,
+		),
+		stkSslAlertMixed: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, stkSSLCollectorSubsystem, "alert_mixed"),
+			"StatusCake SSL Alert Broken boolean",
+			[]string{"domain"}, nil,
 		),
 	}, nil
 }
 
 // Update implements Collector and exposes related metrics
 func (c *stkSSLCollector) Update(ch chan<- prometheus.Metric) error {
-	fmt.Println("ssl.Update()")
 	if err := c.updateStkSSL(ch); err != nil {
 		return err
 	}
@@ -57,13 +109,108 @@ func (c *stkSSLCollector) updateStkSSL(ch chan<- prometheus.Metric) error {
 	}
 	for t := range tests {
 		test := tests[t]
+
 		testStatus := 0
-		fmt.Println(test)
 		if test.Paused == false {
 			testStatus = 1
 		}
-		fmt.Println(testStatus)
-		fmt.Println(test)
+		ch <- prometheus.MustNewConstMetric(
+			c.stkSslUp,
+			prometheus.GaugeValue,
+			float64(testStatus),
+			test.Domain,
+		)
+
+		ctscore, _ := strconv.ParseFloat(test.CertScore, 32)
+		ch <- prometheus.MustNewConstMetric(
+			c.stkSslCertScore,
+			prometheus.GaugeValue,
+			ctscore,
+			test.Domain,
+		)
+
+		ciscore, _ := strconv.ParseFloat(test.CipherScore, 32)
+		ch <- prometheus.MustNewConstMetric(
+			c.stkSslCipherScore,
+			prometheus.GaugeValue,
+			ciscore,
+			test.Domain,
+		)
+
+		certStatus := 0
+		if test.CertStatus == "CERT_OK" {
+			certStatus = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.stkSslCertStatus,
+			prometheus.GaugeValue,
+			float64(certStatus),
+			test.Domain,
+		)
+
+		t, err := time.Parse("2021-03-18 23:59:00", test.ValidUntilUtc)
+		if err != nil {
+			tnow := time.Now()
+			secUntilExpiry := tnow.Sub(t)
+			ch <- prometheus.MustNewConstMetric(
+				c.stkSslValidUntil,
+				prometheus.GaugeValue,
+				float64(secUntilExpiry),
+				test.Domain,
+			)
+		}
+
+		alert := 0
+		if test.AlertReminder {
+			alert = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.stkSslAlertReminder,
+			prometheus.GaugeValue,
+			float64(alert),
+			test.Domain,
+		)
+
+		alert = test.LastReminder
+		ch <- prometheus.MustNewConstMetric(
+			c.stkSslLastReminder,
+			prometheus.GaugeValue,
+			float64(alert),
+			test.Domain,
+		)
+
+		alert = 0
+		if test.AlertExpiry {
+			alert = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.stkSslAlertExpiry,
+			prometheus.GaugeValue,
+			float64(alert),
+			test.Domain,
+		)
+
+		alert = 0
+		if test.AlertBroken {
+			alert = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.stkSslAlertBroken,
+			prometheus.GaugeValue,
+			float64(alert),
+			test.Domain,
+		)
+
+		alert = 0
+		if test.AlertMixed {
+			alert = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.stkSslAlertMixed,
+			prometheus.GaugeValue,
+			float64(alert),
+			test.Domain,
+		)
 	}
 
 	return nil

--- a/globals.go
+++ b/globals.go
@@ -7,17 +7,19 @@ import (
 )
 
 type globalConf struct {
-	listenAddress string
-	metricsPath   string
-	version       string
-	versionCm     string
-	versionTag    string
-	versionEnv    string
-	StkUsername   string
-	StkApikey     string
-	StkTags       string
-	StkInterval   int
-	Resolution    int
+	listenAddress  string
+	metricsPath    string
+	version        string
+	versionCm      string
+	versionTag     string
+	versionEnv     string
+	StkUsername    string
+	StkApikey      string
+	StkTags        string
+	StkInterval    int
+	Resolution     int
+	StkEnableTests bool
+	StkEnableSSL   bool
 }
 
 type globalProm struct {
@@ -53,6 +55,8 @@ var (
 		"",
 		defaultInterval,
 		defaultResolution,
+		false,
+		false,
 	}
 	stkAPI *stk.StkAPI
 	prom   globalProm

--- a/init.go
+++ b/init.go
@@ -27,6 +27,8 @@ func initFlags() error {
 	flagStkApikey := flag.String("stk.apikey", "", "StatusCake API's Apikey. Default: nil (required)")
 	flagStkTags := flag.String("stk.tags", "", "StatusCake Filter Tags separated by comma. Default: <empty>")
 	flagStkInterval := flag.Int("stk.interval", defaultInterval, "StatusCake interval time, in seconds, to gather metrics on API (avoid throtling). Default: 300.")
+	flagEnableTests := flag.Bool("stk.enable-tests", true, "Enable Tests module")
+	flagEnableSSL := flag.Bool("stk.enable-ssl", true, "Enable SSL module")
 
 	flagVersion := flag.Bool("v", false, "prints current version")
 	flag.Usage = usage
@@ -66,6 +68,9 @@ func initFlags() error {
 	if *flagStkInterval != defaultInterval {
 		config.StkInterval = *flagStkInterval
 	}
+
+	config.StkEnableTests = *flagEnableTests
+	config.StkEnableSSL = *flagEnableSSL
 
 	return nil
 }

--- a/stk/main.go
+++ b/stk/main.go
@@ -1,6 +1,7 @@
 package stk
 
 import (
+	"fmt"
 	"log"
 	"net/url"
 	"strconv"
@@ -14,19 +15,23 @@ type StkOptions struct {
 	Tags   string
 }
 
+// StkAPI handle the basic API config and last data.
 type StkAPI struct {
 	client          *statuscake.Client
 	configTags      string
 	waitIntervalSec uint32
+	EnableTests     bool
+	EnableTestsSSL  bool
 	Tests           []*statuscake.Test
+	TestsSSL        []*statuscake.Ssl
 	controlInit     bool
 }
 
-type StkTest statuscake.Test
+// type StkTest statuscake.Test
 
+// NewStkAPI create API instance to communicate with StatusCake API.
 func NewStkAPI(user string, pass string) (*StkAPI, error) {
 
-	// connect to the StatusCake API
 	c, err := statuscake.New(
 		statuscake.Auth{
 			Username: user,
@@ -41,34 +46,56 @@ func NewStkAPI(user string, pass string) (*StkAPI, error) {
 		client:          c,
 		waitIntervalSec: 300,
 		controlInit:     false,
+		EnableTests:     false,
+		EnableTestsSSL:  false,
 	}, nil
 }
 
-// get/set
+// SetConfigTags define Tags on configuration.
 func (stk *StkAPI) SetConfigTags(tags string) {
 	stk.configTags = tags
 }
 
+// GetTags return all tags defined.
 func (stk *StkAPI) GetTags() string {
 	return stk.configTags
 }
 
+// GetTests return all StatusCake Tests from last API discovery.
 func (stk *StkAPI) GetTests() []*statuscake.Test {
 	return stk.Tests
 }
 
+// GetTestsSSL return all StatusCake SSL Tests from last API discovery.
+func (stk *StkAPI) GetTestsSSL() []*statuscake.Ssl {
+	return stk.TestsSSL
+}
+
+// SetWaitInterval define API data scrape wait internval.
 func (stk *StkAPI) SetWaitInterval(sec uint32) {
 	stk.waitIntervalSec = sec
 }
 
+// GetWaitInterval return the wait interval value.
 func (stk *StkAPI) GetWaitInterval() uint32 {
 	return stk.waitIntervalSec
 }
 
-// gather functions
+// SetEnableTests define API data scrape wait internval.
+func (stk *StkAPI) SetEnableTests(v bool) {
+	stk.EnableTests = v
+}
+
+// GetEnableTests return the wait interval value.
+func (stk *StkAPI) GetEnableTests() bool {
+	return stk.EnableTests
+}
+
+// GatherAll retrieves all data for enabled modules.
 func (stk *StkAPI) GatherAll() error {
 	go stk.gatherTest()
 	go stk.gatherTestsData()
+	go stk.gatherTestsSSL()
 	return nil
 }
 
@@ -110,6 +137,22 @@ func (stk *StkAPI) gatherTestsData() {
 				log.Println(err)
 			}
 			test.PerformanceData = perfData
+		}
+		time.Sleep(time.Second * time.Duration(stk.waitIntervalSec))
+	}
+}
+
+func (stk *StkAPI) gatherTestsSSL() {
+	fmt.Println("gatherTestsSSL()")
+	sslCli := statuscake.NewSsls(stk.client)
+	for {
+		ssls, err := sslCli.All()
+		if err != nil {
+			log.Println(err)
+		}
+		stk.TestsSSL = ssls
+		if !stk.controlInit {
+			log.Println(" Initial API discovery returns the Total of SSL Tests:", len(stk.TestsSSL))
 		}
 		time.Sleep(time.Second * time.Duration(stk.waitIntervalSec))
 	}

--- a/stk/main.go
+++ b/stk/main.go
@@ -1,7 +1,6 @@
 package stk
 
 import (
-	"fmt"
 	"log"
 	"net/url"
 	"strconv"
@@ -143,7 +142,6 @@ func (stk *StkAPI) gatherTestsData() {
 }
 
 func (stk *StkAPI) gatherTestsSSL() {
-	fmt.Println("gatherTestsSSL()")
 	sslCli := statuscake.NewSsls(stk.client)
 	for {
 		ssls, err := sslCli.All()


### PR DESCRIPTION
Ref https://github.com/mtulio/statuscake-exporter/issues/5

Based on SSL Test bellow: 
```json
[
  {
    "id": "11231",
    "checkrate": 600,
    "paused": false,
    "domain": "https://me.mydomain.com",
    "issuer_cn": "Let's Encrypt Authority X3",
    "cert_score": "95",
    "cipher_score": "100",
    "cert_status": "CERT_OK",
    "cipher": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
    "valid_from_utc": "2019-07-02 11:51:00",
    "valid_until_utc": "2019-09-30 11:51:00",
    "mixed_content": [],
    "flags": {
      "is_extended": false,
      "has_pfs": true,
      "is_broken": false,
      "is_expired": false,
      "is_missing": false,
      "is_revoked": false,
      "has_mixed": false
    },
    "contact_groups": [
      "123329"
    ],
    "alert_at": "1,7,30",
    "last_reminder": 0,
    "alert_reminder": true,
    "alert_expiry": true,
    "alert_broken": true,
    "alert_mixed": false,
    "last_updated_utc": "2019-07-15 04:13:37"
  }
]

```

Exposing SSL metrics. For each data on API Im creating these metrics:

```
statuscake_ssl_alert_broken{domain="https://me.mydomain.com"} 1
statuscake_ssl_alert_expiry{domain="https://me.mydomain.com"} 1
statuscake_ssl_alert_mixed{domain="https://me.mydomain.com"} 0
statuscake_ssl_alert_reminder{domain="https://me.mydomain.com"} 1
statuscake_ssl_cert_score{domain="https://me.mydomain.com"} 95
statuscake_ssl_cert_status{domain="https://me.mydomain.com"} 1
statuscake_ssl_cipher_score{domain="https://me.mydomain.com"} 100
statuscake_ssl_last_reminder{domain="https://me.mydomain.com"} 0
statuscake_ssl_up{domain="https://me.mydomain.com"} 1
statuscake_ssl_valid_util_sec{domain="https://me.mydomain.com"} 9.223372036854776e+18

```

Even looking in data and some of them is static config, could be an good idea expose it to create some monitoring alerts.