### PR TITLE
Add basic docs for Docker, binary compiled to work w/o glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:latest
+RUN apk update && \
+    apk add ca-certificates && \
+    update-ca-certificates
+
+COPY bin/statuscake-exporter /statuscake-exporter
+
+ENTRYPOINT ["/statuscake-exporter"]

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ update:
 build:
 	@test -d ./bin || mkdir ./bin
 	 CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
-		go build  \
+		go build \
 		-ldflags "$(LDFLAGS)" \
 		$(BUILD_TAGS) \
 		-o $(BIN_NAME) && strip $(BIN_NAME)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ update:
 .PHONY: build
 build:
 	@test -d ./bin || mkdir ./bin
-	 CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
 		go build \
 		-ldflags "$(LDFLAGS)" \
 		$(BUILD_TAGS) \

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ update:
 .PHONY: build
 build:
 	@test -d ./bin || mkdir ./bin
-	GOOS=$(GOOS) GOARCH=$(GOARCH) \
-		go build \
+	 CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) \
+		go build  \
 		-ldflags "$(LDFLAGS)" \
 		$(BUILD_TAGS) \
 		-o $(BIN_NAME) && strip $(BIN_NAME)

--- a/Makefile-glob.mk
+++ b/Makefile-glob.mk
@@ -25,6 +25,9 @@ GIT_DESCRIBE := $(shell git describe --tags --always)
 GOOS := linux
 GOARCH := amd64
 
+CGO_ENABLED := 0
+
+
 LDFLAGS :=
 LDFLAGS += -X main.VersionCommit=$(GIT_COMMIT)
 LDFLAGS += -X main.VersionTag=$(GIT_DESCRIBE)

--- a/Makefile-glob.mk
+++ b/Makefile-glob.mk
@@ -27,7 +27,6 @@ GOARCH := amd64
 
 CGO_ENABLED := 0
 
-
 LDFLAGS :=
 LDFLAGS += -X main.VersionCommit=$(GIT_COMMIT)
 LDFLAGS += -X main.VersionTag=$(GIT_DESCRIBE)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ docker run -it mtulio/statuscake-exporter:v0.3.1 \
   -stk.apikey $STATUSCAKE_APIKEY
 ```
 
+OR, to build your own Docker image:
+
+`make build`
+
+The binary will be created on `./bin` dir.
+
+`docker build  .`
+
+This will create a docker image.
+
+Set STATUSCAKE_APIKEY and STATUSCAKE_USER variables for Docker image, and  `docker run $image-id-here`
+
 ## CONTRIBUTOR
 
 You can contribute with three ways: using, testing and developing.


### PR DESCRIPTION
The CGO_ENABLED flag was breaking compatibility with alpine linux, which does not support glibc.  

Please let me know if you need anything else to get this merged, the Docker file works great for me so hopefully the little documentation will help others.